### PR TITLE
Make API URL configurable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ build/
 # Environment variables
 .env
 .env.*
+!**/.env.example
 
 # Logs
 npm-debug.log*

--- a/README.md
+++ b/README.md
@@ -19,6 +19,18 @@ After installing the dependencies, start the local development server:
 npm run dev
 ```
 
+### Environment variables
+
+The frontend expects the API base URL to be provided via a Vite environment
+variable named `VITE_API_URL`. Create a `.env` file in the `frontend` directory
+based on the included `.env.example` and adjust the URL if necessary:
+
+```bash
+cp frontend/.env.example frontend/.env
+```
+
+The default value points to a local backend running on port `8080`.
+
 The app will be served with hot module reload at the URL printed in the console.
 
 ## Project structure

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,0 +1,1 @@
+VITE_API_URL=http://localhost:8080

--- a/frontend/src/contexts/AuthContext.jsx
+++ b/frontend/src/contexts/AuthContext.jsx
@@ -16,7 +16,8 @@ export const AuthProvider = ({ children }) => {
   const [token, setToken]   = useState(localStorage.getItem('token'));
   const [loading, setLoading] = useState(true);
 
-  const API = 'http://localhost:8080/api/auth';
+  const API_BASE = import.meta.env.VITE_API_URL || 'http://localhost:8080';
+  const API = `${API_BASE}/api/auth`;
 
   // Security: Check token expiration
   const isTokenExpired = (token) => {


### PR DESCRIPTION
## Summary
- read API base URL from `import.meta.env.VITE_API_URL`
- document the environment variable and add a sample `.env` file
- unignore `.env.example` so it is tracked

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite: not found)*

------
https://chatgpt.com/codex/tasks/task_e_685a16e9f2ec8320bfa6fd8f180b3bb0