### PR TITLE
Improve AddNewTour error handling

### DIFF
--- a/frontend/src/components/tours/AddNewTour.jsx
+++ b/frontend/src/components/tours/AddNewTour.jsx
@@ -448,6 +448,10 @@ export default function AddNewTour({ onClose }) {
         headers: getAuthHeaders(),
         body: JSON.stringify(tourData),
       });
+      if (res.status === 403) {
+        alert('You are not authorized to publish tours.');
+        return;
+      }
       if (!res.ok) throw new Error('Failed to publish tour');
       alert('Tour published successfully');
       if (onClose) onClose();


### PR DESCRIPTION
## Summary
- show a clearer message when publishing a tour returns HTTP 403

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_685a24f84b00832082c9aca1e5a150d2